### PR TITLE
Optimized with TSON.revive(TSON.encapsulate())

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ if (!globalVar.DOMException) {
 var TSON = new Typeson().register(structuredCloningThrowing);
 
 function realisticStructuredClone(obj) {
-    return TSON.parse(TSON.stringify(obj));
+    return TSON.revive(TSON.encapsulate(obj));
 }
 
 module.exports = realisticStructuredClone;


### PR DESCRIPTION
This will omit stringifying the contents and instead to the clone in objects only.